### PR TITLE
Fix typo on ESP32 AUX pin connection

### DIFF
--- a/examples/esp32_e22_getConfiguration/esp32_e22_getConfiguration.ino
+++ b/examples/esp32_e22_getConfiguration/esp32_e22_getConfiguration.ino
@@ -8,7 +8,7 @@
  * M1         ----- 21 (or 3.3v)
  * RX         ----- TX2 (PullUP)
  * TX         ----- RX2 (PullUP)
- * AUX        ----- 15  (PullUP)
+ * AUX        ----- 18  (PullUP)
  * VCC        ----- 3.3v/5v
  * GND        ----- GND
  *


### PR DESCRIPTION
Small typo in comment. Code used AUX as GPIO18, but comment indicated it was on GPIO15 